### PR TITLE
Fix setting captureTimeout config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ var BrowserStackBrowser = function(id, emitter, args, logger,
   this.name = browserName + ' on BrowserStack';
 
   var bsConfig = config.browserStack || {};
-  var captureTimeout = config.captureTimeout || 0;
+  var captureTimeout = bsConfig.captureTimeout || 0;
   var captureTimeoutId;
   var retryLimit = bsConfig.retryLimit || 3;
 


### PR DESCRIPTION
Pretty much just does what it says. :)

There is currently a bug with setting `captureTimeout` due to attempting to read from the wrong object.
