### PR TITLE
Update browserstacktunnel-wrapper to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
     "browserstack": "~1.0",
-    "browserstacktunnel-wrapper": "~1.2.1",
+    "browserstacktunnel-wrapper": "~1.3.0",
     "q": "~0.9.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
Use latest version of the tunnel wrapper as it now uses the win32 binary as in:

https://github.com/pghalliday/node-BrowserStackTunnel/commit/c3748abcc9988aca7e8857afe457889e4543a035

Couldn't get this launcher to work on Windows, using 1.3.0 was the fix.
