### PR TITLE
feat: add extra logs as option after finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ module.exports = function(config) {
 - `build` the BS worker build name (optional)
 - `name` the BS worker name (optional)
 - `project` the BS worker project name (optional)
+- `extraLog` log extra info after each browser is finished, like browser percentage or total execution time (optional)
 
 ### Per browser options
 - `device` name of the device

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "browserstack": "~1.0",
     "browserstacktunnel-wrapper": "~1.2.1",
+    "chalk": "^0.5.1",
+    "pretty-ms": "^1.0.0",
     "q": "~0.9.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
Added a new option in the `browserStack` config to log more info about the total execution / net time, and the browsers execution percentage over total to give a last recap of everything.

Still need some feedback about the formatting : 

![xgk96](https://cloud.githubusercontent.com/assets/6033345/4430866/6b43d4fa-464b-11e4-8777-de7d2eef9825.png)

And some usages:
- Is the option name `extraLogs` good 
- I've used chalk to colorize the output, but it's not mandatory
- Since it's some recap logs, I've not used the `logger` but a basic `console.info`, but I can go back with this
