### PR TITLE
feat: Adds support for iOS simulators and opens opportunities for more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,36 @@ module.exports = function(config) {
 - `os` which platform ?
 - `os_version` version of the platform
 
+### Browserstack iOS simulators
+BrowserStack provides real iOS devices for Selenium and JS testing. All your tests are by default executed on the real iOS devices. Thus, you would not find the list of iOS simulators in the documentation or the browsers.json file. The list below for the iOS simulators is complete and you should be able to test smoothly on these devices.  
+BrowserStack are actively working on improving the performance of real iOS devices and moving forward, they will be completely replacing the simulators with real devices. Meantime if you're facing issues with real devices (like no
+reaction within specified time intervals) you can use simulators.
+
+####List of iOS simulators
+- `device: 'iPad 3rd', 'os_version': '5.1'`
+- `device: 'iPad 3rd (6.0)', 'os_version': '6.0'`
+- `device: 'iPad Mini', 'os_version': '7.0'`
+- `device: 'iPad 4th', 'os_version': '7.0'`
+- `device: 'iPhone 4S', 'os_version': '5.1'`
+- `device: 'iPhone 4S (6.0)', 'os_version': '6.0'`
+- `device: 'iPhone 5', 'os_version': '6.0'`
+- `device: 'iPhone 5S', 'os_version': '7.0'`
+
+####Example
+```js
+customLaunchers: {
+  iPad_3: {
+    real_mobile: false,
+    device: 'iPad 3rd (6.0)',
+    os: 'ios',
+    'os_version': '6.0',
+    'browser_version': null,
+    browser: 'Mobile Safari'
+  }
+}
+```
+
+
 [BrowserStack's REST API documentation](http://www.browserstack.com/automate/rest-api#rest-api-browsers) 
 explains how to retrieve a list of desired capabilities for browsers.
 

--- a/index.js
+++ b/index.js
@@ -70,6 +70,22 @@ var formatError = function(error) {
   return error.toString();
 };
 
+var clone = function (obj) {
+  return extend({}, obj);
+};
+
+var extend = function (what, wit) {
+  var extObj;
+  var witKeys = Object.keys(wit);
+
+  extObj = Object.keys(what).length ? clone(what) : {};
+
+  witKeys.forEach(function (key) {
+    Object.defineProperty(extObj, key, Object.getOwnPropertyDescriptor(wit, key));
+  });
+
+  return extObj;
+};
 
 var BrowserStackBrowser = function(id, emitter, args, logger,
                                    /* config */ config,
@@ -92,13 +108,8 @@ var BrowserStackBrowser = function(id, emitter, args, logger,
   var retryLimit = bsConfig.retryLimit || 3;
 
   this.start = function(url) {
-
     // TODO(vojta): handle non os/browser/version
-    var settings = {
-      os: args.os,
-      os_version: args.os_version,
-      device: args.device,
-      browser: args.browser,
+    var settings = extend(args, {
       tunnelIdentifier: bsConfig.tunnelIdentifier,
       // TODO(vojta): remove "version" (only for B-C)
       browser_version: args.browser_version || args.version || 'latest',
@@ -108,8 +119,8 @@ var BrowserStackBrowser = function(id, emitter, args, logger,
       project: bsConfig.project,
       name: bsConfig.name || 'Karma test',
       build: bsConfig.build || process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER ||
-             process.env.BUILD_TAG || process.env.CIRCLE_BUILD_NUM || null
-    };
+      process.env.BUILD_TAG || process.env.CIRCLE_BUILD_NUM || null
+    });
 
     this.url = url;
     tunnel.then(function() {


### PR DESCRIPTION
Let me start with the issue - while testing using browserstack iOS devices I was constantly hitting timeouts. Changing timeouts to big number didn't help, so I wrote an email to browserstack team and got following reply:
"I checked the build you shared and see the issue you faced. I have shared the information with the team and will get back to you as soon as I have an update.

In the meantime, could you run your tests on iOS simulators? To run your tests on iOS simulators, you just need to specify the following capabilities:
“real_mobile” : false,
“device” : “iPad 3rd (6.0)”, 
“os” : “ios”, 
“os_version” : “6.0”, 
“browser_version” : “null”, 
“browser” : “Mobile Safari”,

You can test on any of the following devices:
•	“device” : “iPad 3rd”, “os_version” : “5.1”
•	“device” : “iPad 3rd (6.0)”, “os_version” : “6.0”
•	“device” : “iPad Mini”, “os_version” : “7.0”
•	“device” : “iPad 4th”, “os_version” : “7.0”
•	“device” : “iPhone 4S”, “os_version” : “5.1”
•	“device” : “iPhone 4S (6.0)”, “os_version” : “6.0”
•	“device” : “iPhone 5”, “os_version” : “6.0”
•	“device” : “iPhone 5S”, “os_version” : “7.0”
Please give it a try and let me know how things go.".


I looked at how browserstack plugin is working and I had to make minor modification to allow passing more configuration settings to browserstacktunnel-wrapper. I also updated readme to include some information about iOS simulators.

Please let me know if you have any questions. Thank you.
