### PR TITLE
Updated browserstack library

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "browserstack": "~1.0",
+    "browserstack": "1.1.1",
     "browserstacktunnel-wrapper": "~1.3.0",
     "q": "~0.9.6"
   },


### PR DESCRIPTION
Includes a bug fix for network errors.

Previously, if a browerstack request errored then it would exit the process and leave the browserstack tunnel wide open.