### PR TITLE
Pass through the 'real_mobile' argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ module.exports = function(config) {
 
 ### Per browser options
 - `device` name of the device
+- `real_mobile ` allow browserstack to use a simulator
 - `browser` name of the browser
 - `browser_version` version of the browser
 - `os` which platform ?

--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ var BrowserStackBrowser = function(id, emitter, args, logger,
       os_version: args.os_version,
       device: args.device,
       browser: args.browser,
+      real_mobile : args.real_mobile || 'true', // requires strings instead of booleans
       tunnelIdentifier: bsConfig.tunnelIdentifier,
       // TODO(vojta): remove "version" (only for B-C)
       browser_version: args.browser_version || args.version || 'latest',


### PR DESCRIPTION
This is required by browserstack to enable usage of ios simulators.