### PR TITLE
Exposing the polling timeout setting.

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ var BrowserStackBrowser = function(id, emitter, args, logger,
   var captureTimeout = config.captureTimeout || 0;
   var captureTimeoutId;
   var retryLimit = bsConfig.retryLimit || 3;
+  var pollingTimeout = bsConfig.pollingTimeout || 1000;
 
   this.start = function(url) {
 
@@ -151,7 +152,7 @@ var BrowserStackBrowser = function(id, emitter, args, logger,
               whenRunning();
             } else {
               log.debug('%s job with id %s still in queue.', browserName, workerId);
-              setTimeout(waitForWorkerRunning, 1000);
+              setTimeout(waitForWorkerRunning, pollingTimeout);
             }
           });
         };
@@ -160,7 +161,7 @@ var BrowserStackBrowser = function(id, emitter, args, logger,
           whenRunning();
         } else {
           log.debug('%s job queued with id %s.', browserName, workerId);
-          setTimeout(waitForWorkerRunning, 1000);
+          setTimeout(waitForWorkerRunning, pollingTimeout);
         }
 
       });


### PR DESCRIPTION
BrowserStack has recently implemented rate limiting on their API at 120 requests per minute.  Based on the number of browsers you're using, the time each browser takes, and the number of parallel workers your BrowserStack plan supports, this number is now easily reachable.

Exposing the timeout value when polling queued workers allows us to reduce the total number of API calls.  Increasing this value may result in a delay reporting that a test has changed from queued to running, but we would rather lose those few seconds than reach the throttling limit.