### PR TITLE
Fix BS Rate Limit error

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ var BrowserStackBrowser = function(id, emitter, args, logger,
               whenRunning();
             } else {
               log.debug('%s job with id %s still in queue.', browserName, workerId);
-              setTimeout(waitForWorkerRunning, 1000);
+              setTimeout(waitForWorkerRunning, 10000);
             }
           });
         };


### PR DESCRIPTION
According to communicate with BrowserStack, they suggest update this to avoid "Rate Limit Exceeded" error because of changes in their JavaScript API policy.