### PR TITLE
Add proxy settings for BrowserstackLocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ module.exports = function(config) {
 - `name` the BS worker name (optional)
 - `project` the BS worker project name (optional)
 - `binaryBasePath` the BS binary base bath, you can also use `BROWSER_STACK_BINARY_BASE_PATH` env variable. This will override the default and set the base path to the BS local binary (optional)
+- `proxyHost` the host of your proxy as you would define it for BrowserstackLocal
+- `proxyPort` the port of your proxy as you would define it for BrowserstackLocal
+- `proxyUser` the username used for authentication with you proxy as you would define it for BrowserstackLocal
+- `proxyPass` the password used for authenticationwit your proxy as you would define it for BrowserstackLocal
 
 ### Per browser options
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,11 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
       name: config.hostname,
       port: config.port,
       sslFlag: 0
-    }]
+    }],
+    proxyHost: bsConfig.proxyHost || null,
+    proxyPort: bsConfig.proxyPort || null,
+    proxyUser: bsConfig.proxyUser || null,
+    proxyPass: bsConfig.proxyPass || null
   }
 
   if (bsConfig.startTunnel === false) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
     "browserstack": "1.2.0",
-    "browserstacktunnel-wrapper": "~1.4.0",
+    "browserstacktunnel-wrapper": "~1.4.2",
     "q": "~1.4.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Added the ability to set the proxy-settings on the BrowserstackLocal-tunnel. I needed those to be able to use the plugin from behind a corporate proxy. 

Sorry for the resubmit, I did use the wrong email-address for the commit and ran into issues with the google-licensing bot.