### PR TITLE
Bumped browserstacktunnel-wrapper version. Resolves EACCESS error #23

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
     "browserstack": "1.1.1",
-    "browserstacktunnel-wrapper": "~1.3.0",
+    "browserstacktunnel-wrapper": "~1.4.0",
     "q": "~0.9.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
Bumps the version for `browserstacktunnel-wrapper` to resolve `EACCESS` and `[Error: invalid signature: 0x140315]` errors faced by some users.

See [karma-browserstack-launcher#23](https://github.com/karma-runner/karma-browserstack-launcher/issues/23) and [browserstack-runner#124](https://github.com/browserstack/browserstack-runner/issues/124).
