### PR TITLE
fix: Update browserstacktunnel-wrapper & others

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,13 @@ var createBrowserStackTunnel = function(logger, config, emitter) {
     return q();
   }
 
-  if (!bsConfig.tunnelIdentifier) {
-    bsConfig.tunnelIdentifier = 'karma' + Math.random();
+  if (!bsConfig.localIdentifier) {
+    if (bsConfig.tunnelIdentifier) {
+      // Back compat; the option was renamed.
+      bsConfig.localIdentifier = bsConfig.tunnelIdentifier;
+      delete bsConfig.tunnelIdentifier;
+    }
+    bsConfig.localIdentifier = 'karma' + Math.random();
   }
 
   log.debug('Establishing the tunnel on %s:%s', config.hostname, config.port);
@@ -20,7 +25,7 @@ var createBrowserStackTunnel = function(logger, config, emitter) {
   var deferred = q.defer();
   var tunnel = new BrowserStackTunnel({
     key: process.env.BROWSER_STACK_ACCESS_KEY || bsConfig.accessKey,
-    tunnelIdentifier: bsConfig.tunnelIdentifier,
+    localIdentifier: bsConfig.localIdentifier,
     jarFile: process.env.BROWSER_STACK_TUNNEL_JAR || bsConfig.jarFile,
     hosts: [{
       name: config.hostname,

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "browserstack": "1.1.1",
-    "browserstacktunnel-wrapper": "~1.3.0",
-    "q": "~0.9.6"
+    "browserstack": "1.2.0",
+    "browserstacktunnel-wrapper": "~1.4.0",
+    "q": "~1.4.1"
   },
   "peerDependencies": {
     "karma": ">=0.9"
   },
   "license": "MIT",
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-bump": "~0.0.7",
-    "grunt-npm": "~0.0.2",
-    "grunt-auto-release": "~0.0.2"
+    "grunt": "~0.4.5",
+    "grunt-auto-release": "~0.0.2",
+    "grunt-bump": "~0.3.1",
+    "grunt-npm": "~0.0.2"
   },
   "contributors": [
     "L42y <423300@gmail.com>",


### PR DESCRIPTION
The browserstacktunnel-wrapper package used by Karma was relying on
outdated interface to the BrowserStackTunnel binary; some options no longer
work, others were not supported.

For back compat fallback to the old tunnelIdentifier option was added.

Maybe the fallback is not needed if the minor is bumped?

The commit that updated the options was https://github.com/pghalliday/node-BrowserStackTunnel/commit/0b44eab9f712998439168b07344cfa062902e79f