### PR TITLE
feat(config):  added ability to specify binary base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ module.exports = function(config) {
 - `build` the BS worker build name (optional)
 - `name` the BS worker name (optional)
 - `project` the BS worker project name (optional)
+- `binaryBasePath` the BS binary base bath, you can also use `BROWSER_STACK_BINARY_BASE_PATH` env variable. This will override the default and set the base path to the BS local binary (optional)
 
 ### Per browser options
 


### PR DESCRIPTION
Node-BrowserStackTunnel allows for the specifying of the binary's bin path. The proposed PR allows for an option to be set in the karma config, browserstack object and it will pass through to node-BrowserStackTunnel.

```
    browserStack: {
      project: 'browserstack-karma',
      ...
      binaryBasePath: '/Applications/'
    },
```

Then just as they do in the Node-BrowserStackTunnel, I switch on OS and apply the appropriate  property:

```
 osxBin: 'your_bin_dir', // optionally override the default bin directory for the OSX binary
 linux32Bin: 'your_bin_dir', // optionally override the default bin directory for the Linux 32 bit binary
 linux64Bin: 'your_bin_dir', // optionally override the default bin directory for the Linux 64 bit binary
 win32Bin: 'your_bin_dir', // optionally override the default bin directory for the win32 binary
```