### PR TITLE
inherit base launcher and override forceKill

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,8 +119,11 @@ var formatError = function (error) {
 
 var BrowserStackBrowser = function (id, emitter, args, logger,
   /* config */ config,
-  /* browserStackTunnel */ tunnel, /* browserStackClient */ client) {
+  /* browserStackTunnel */ tunnel, /* browserStackClient */ client,
+  baseLauncherDecorator) {
   var self = this
+
+  baseLauncherDecorator(self)
 
   var workerId = null
   var captured = false
@@ -226,6 +229,14 @@ var BrowserStackBrowser = function (id, emitter, args, logger,
     if (done) {
       alreadyKilling.promise.then(done)
     }
+  }
+
+  this.forceKill = function () {
+    var self = this
+
+    return q.promise(function (resolve) {
+      self.kill(resolve)
+    })
   }
 
   this.markCaptured = function () {


### PR DESCRIPTION
fixes #47

Inherit base launcher for eventing compatibility and override `forceKill`(that's the only one not overridden) based on the one here (https://github.com/karma-runner/karma/blob/master/lib/launcher.js#L74-L80) but using `q` as Promise.