### PR TITLE
fix: Pass localIdentifier to browserstacktunnel-wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
   var bsBinaryBasePath = process.env.BROWSER_STACK_BINARY_BASE_PATH || bsConfig.binaryBasePath || null
   var bsRunConfig = {
     key: process.env.BROWSER_STACK_ACCESS_KEY || bsConfig.accessKey,
-    tunnelIdentifier: bsConfig.tunnelIdentifier,
+    localIdentifier: bsConfig.localIdentifier || bsConfig.tunnelIdentifier || 'karma' + Math.random(),
     jarFile: process.env.BROWSER_STACK_TUNNEL_JAR || bsConfig.jarFile,
     hosts: [{
       name: config.hostname,
@@ -19,17 +19,10 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
     }]
   }
 
+  bsConfig.tunnelIdentifier = bsRunConfig.localIdentifier
+
   if (bsConfig.startTunnel === false) {
     return q()
-  }
-
-  if (!bsConfig.localIdentifier) {
-    if (bsConfig.tunnelIdentifier) {
-      // Back compat; the option was renamed.
-      bsConfig.localIdentifier = bsConfig.tunnelIdentifier
-      delete bsConfig.tunnelIdentifier
-    }
-    bsConfig.localIdentifier = 'karma' + Math.random()
   }
 
   if (bsBinaryBasePath) {


### PR DESCRIPTION
A [recent change](https://github.com/karma-runner/karma-browserstack-launcher/commit/2dcb6adde8fc16b1c8b3e8c0a1b9d28b4dae3c09) broke the ability to run tests parallely using multiple `BrowserStackLocal` binary instances.

This fix restores that functionality.

The [browserstacktunnel-wrapper](https://github.com/pghalliday/node-BrowserStackTunnel) module requires the `localIdentifier` option set, whereas the [browserstack](https://github.com/scottgonzalez/node-browserstack/) module requires the `tunnelIdentifier` option when creating a browser-worker.