### PR TITLE
fix: Avoid setting tunnelIdentifier if startTunnel is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module.exports = function(config) {
 - `username` your BS username (email), you can also use `BROWSER_STACK_USERNAME` env variable.
 - `accessKey` your BS access key (password), you can also use `BROWSER_STACK_ACCESS_KEY` env variable.
 - `startTunnel` do you wanna establish the BrowserStack tunnel ? (defaults to `true`)
+- `tunnelIdentifier` in case you want to start the BrowserStack tunnel outside `karma` by setting `startTunnel` to `false`, set the identifier passed to the `-localIdentifier` option here (optional)
 - `retryLimit` how many times do you want to retry to capture the browser ? (defaults to `3`)
 - `captureTimeout` the browser capture timeout (defaults to `120`)
 - `timeout` the BS worker timeout (defaults to `300`

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
   var bsBinaryBasePath = process.env.BROWSER_STACK_BINARY_BASE_PATH || bsConfig.binaryBasePath || null
   var bsRunConfig = {
     key: process.env.BROWSER_STACK_ACCESS_KEY || bsConfig.accessKey,
-    localIdentifier: bsConfig.localIdentifier || bsConfig.tunnelIdentifier || 'karma' + Math.random(),
+    localIdentifier: bsConfig.localIdentifier || bsConfig.tunnelIdentifier,
     jarFile: process.env.BROWSER_STACK_TUNNEL_JAR || bsConfig.jarFile,
     hosts: [{
       name: config.hostname,
@@ -19,11 +19,13 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
     }]
   }
 
-  bsConfig.tunnelIdentifier = bsRunConfig.localIdentifier
-
   if (bsConfig.startTunnel === false) {
+    bsConfig.tunnelIdentifier = bsRunConfig.localIdentifier
     return q()
   }
+
+  bsRunConfig.localIdentifier = bsRunConfig.localIdentifier || 'karma' + Math.random()
+  bsConfig.tunnelIdentifier = bsRunConfig.localIdentifier
 
   if (bsBinaryBasePath) {
     switch (os.platform()) {


### PR DESCRIPTION
Providing `startTunnel` as `false` currently sets the `tunnelIdentifier` for the browser-worker to a random string, causing tests to fail.

If a tunnelIdentifier or localIdentifier is set in config, it is used as the tunnelIdentifier
when creating a new browser-worker. This is useful if the tunnel is created outside of `karma` by running the binary, optionally with a `localIdentifier` parameter.

If not set and startTunnel is true, we generate a random `localIdentifier` and `tunnelIdentifier`.