### PR TITLE
fix: Capture timeout occurs even after tests have run successfully

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ var BrowserStackBrowser = function (id, emitter, args, logger,
             case 'running':
               log.debug('%s job started with id %s', browserName, workerId)
 
-              if (captureTimeout) {
+              if (captureTimeout && !captured) {
                 captureTimeoutId = setTimeout(self._onTimeout, captureTimeout)
               }
               break
@@ -218,6 +218,12 @@ var BrowserStackBrowser = function (id, emitter, args, logger,
         log.debug('Killing %s (worker %s).', browserName, workerId)
         client.terminateWorker(workerId, function () {
           log.debug('%s (worker %s) successfully killed.', browserName, workerId)
+
+          if (captureTimeoutId) {
+            clearTimeout(captureTimeoutId)
+            captureTimeoutId = null
+          }
+
           workerId = null
           captured = false
           alreadyKilling.resolve()


### PR DESCRIPTION
Fixes #17 

One scenario where Karma reports a failed capture even when things are fine is:
1. Creating a worker with captureTimeout starts [the timer](https://github.com/karma-runner/karma-browserstack-launcher/blob/dba17478074bd12e03a1894579b7de93c31c110f/index.js#L194)
2. Webpage in browser connects to Karma before we're able to poll and determine that the work has entered 'running' state (`captured = true`). Particularly happens with Safari on MacOSX
3. Tests complete and worker is killed before capture timeout occurs, setting `captured = false`
4. On timeout, we check the 'captured' state and find it to be false, causing a restart of the worker
 
Here's [a test run](https://travis-ci.org/shirish87/angular/jobs/101395993#L899) with some extra logging for this scenario.