### PR TITLE
fix: urlencode proxy username and password

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ var createBrowserStackClient = function (/* config.browserStack */config) {
   if (config.proxyHost && config.proxyPort) {
     config.proxyProtocol = config.proxyProtocol || 'http'
     var proxyAuth = (config.proxyUser && config.proxyPass)
-      ? (config.proxyUser + ':' + config.proxyPass + '@') : ''
+      ? (encodeURIComponent(config.proxyUser) + ':' + encodeURIComponent(config.proxyPass) + '@') : ''
     options.proxy = config.proxyProtocol + '://' + proxyAuth + config.proxyHost + ':' + config.proxyPort
   }
 


### PR DESCRIPTION
Fix for proxy credentials containing special characters such as `?`.