### PR TITLE
Use separate property to shutdown workers

### DIFF
--- a/worker-manager.js
+++ b/worker-manager.js
@@ -7,6 +7,7 @@ function WorkerManager () {
   this._pollHandle = null
   this.workers = {}
   this.isPolling = false
+  this.shouldShutdown = false
 }
 
 WorkerManager.prototype.registerWorker = function registerWorker (workerData) {
@@ -47,7 +48,7 @@ WorkerManager.prototype.updateWorker = function updateWorker (workerData) {
 }
 
 WorkerManager.prototype.startPolling = function startPolling (client, pollingTimeout, callback) {
-  if (this.isPolling) {
+  if (this.isPolling || this.shouldShutdown) {
     return
   }
 
@@ -88,7 +89,7 @@ WorkerManager.prototype.stopPolling = function stopPolling () {
     this._pollHandle = null
   }
 
-  this.isPolling = false
+  this.shouldShutdown = true
 }
 
 // expose a single, shared instance of WorkerManager


### PR DESCRIPTION
Fixes https://github.com/karma-runner/karma-browserstack-launcher/issues/62


I reproduced #62 that happens sometimes. After some live debugging in my stucked process, I discovered the workers were still polling, confirming @willfrew findings

The main reason is because `startPolling` function calls `client.getWorkers` which is a request to browserstack. This call is asynchronous, and therefore, if `stopPolling` is called when `client.getWorkers` happens, polling won't stop.
(See https://github.com/karma-runner/karma-browserstack-launcher/pull/68/files#diff-63071f9e1d26dc7201e29523f37a0873R58)

`stopPolling` was doing 2 things:
  * call `clearTimeout` to stop `startPolling` to be called. This has only effect is `startPolling` is not being processed.
  * set `isPolling = false`. I don't see any effect of doing that.


To reproduce, you can comment the `clearTimeout` call in `stopPolling` (line 88)

In the original comment on #62, the behavior is the same (see F and D)
```
A: Shutting down the tunnel.
C: Started polling
B: workerManager.isPolling true
E: this._pollHandle { _called: true,
  _idleTimeout: 1000,
  _idlePrev: null,
  _idleNext: null,
  _idleStart: 24300,
  _onTimeout: [Function],
  _repeat: null
}
F: Stopping Polling    # We stop polling but there is nothing to clear, `startPolling` was already called
D: gotWorkers          # Here is the proof, we were fetching workers
C: Started polling     # So we start polling again
D: gotWorkers
C: Started polling
D: gotWorkers
```