### PR TITLE
feat: adding BrowserStack reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ module.exports = function(config) {
 - `os` which platform ?
 - `os_version` version of the platform
 
+### BrowserStack reporter
+
+To report session results back to BrowserStack for display on your BrowserStack dashboard, use the following additional configuration:
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    // The rest of your karma config is here
+    // ...
+    reporters: ['dots', 'browserStack']
+  })
+}
+```
+
 ### Browserstack iOS simulators
 
 By default, your Selenium and JS tests will run on real iOS devices on BrowserStack. Since we are in the implementation phase, we are still working on a few things, such as adding more devices, ability to test on local URLs, etc.

--- a/browserstack-reporter.js
+++ b/browserstack-reporter.js
@@ -1,0 +1,54 @@
+var Browserstack = require('browserstack')
+
+var BrowserStackReporter = function (logger, /* BrowserStack:sessionMapping */ sessionMapping) {
+  var log = logger.create('reporter.browserlabs')
+
+  var pendingUpdates = 0
+  var callWhenFinished = function () {}
+
+  var exitIfAllFinished = function () {
+    if (pendingUpdates === 0) {
+      callWhenFinished()
+    }
+  }
+
+  // We're only interested in the final results per browser
+  this.onBrowserComplete = function (browser) {
+    var browserId = browser.launchId || browser.id
+
+    var result = browser.lastResult
+
+    if (result.disconnected) {
+      log.error('✖ Test Disconnected')
+    }
+
+    if (result.error) {
+      log.error('✖ Test Errored')
+    }
+
+    if (browserId in sessionMapping) {
+      pendingUpdates++
+      var browserstackClient = Browserstack.createAutomateClient(sessionMapping.credentials)
+
+      var apiStatus = !(result.failed || result.error || result.disconnected) ? 'completed' : 'error'
+
+      browserstackClient.updateSession(sessionMapping[browserId], {
+        status: apiStatus
+      }, function (error, session) {
+        if (error) {
+          // TODO
+        }
+        pendingUpdates--
+        exitIfAllFinished()
+      })
+    }
+  }
+
+  // Wait until all updates have been pushed to Browserstack
+  this.onExit = function (done) {
+    callWhenFinished = done
+    exitIfAllFinished()
+  }
+}
+
+module.exports = BrowserStackReporter

--- a/browserstack-reporter.js
+++ b/browserstack-reporter.js
@@ -14,8 +14,6 @@ var BrowserStackReporter = function (logger, /* BrowserStack:sessionMapping */ s
 
   // We're only interested in the final results per browser
   this.onBrowserComplete = function (browser) {
-    var browserId = browser.launchId || browser.id
-
     var result = browser.lastResult
 
     if (result.disconnected) {
@@ -26,15 +24,15 @@ var BrowserStackReporter = function (logger, /* BrowserStack:sessionMapping */ s
       log.error('✖ Test Errored')
     }
 
+    var browserId = browser.launchId || browser.id
     if (browserId in sessionMapping) {
       pendingUpdates++
       var browserstackClient = Browserstack.createAutomateClient(sessionMapping.credentials)
-
       var apiStatus = !(result.failed || result.error || result.disconnected) ? 'completed' : 'error'
 
       browserstackClient.updateSession(sessionMapping[browserId], {
         status: apiStatus
-      }, function (error, session) {
+      }, function (error) {
         if (error) {
           log.error('✖ Could not update BrowserStack status')
           log.debug(error)

--- a/browserstack-reporter.js
+++ b/browserstack-reporter.js
@@ -36,7 +36,8 @@ var BrowserStackReporter = function (logger, /* BrowserStack:sessionMapping */ s
         status: apiStatus
       }, function (error, session) {
         if (error) {
-          // TODO
+          log.error('✖ Could not update BrowserStack status')
+          log.debug(error)
         }
         pendingUpdates--
         exitIfAllFinished()


### PR DESCRIPTION
This marks the status of any failed Browserstack Automate session to "error", so that the session appears red in the Browsertack web interface (without this all builds appear green).

solves #72 