### PR TITLE
Permit overriding `name`, `build`, and `project` on a per-browser basis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ module.exports = function(config) {
 - `browser_version` version of the browser
 - `os` which platform ?
 - `os_version` version of the platform
+- `build` the BS worker build name (optional, defaults to global)
+- `name` the BS worker name (optional, defaults to global)
+- `project` the BS worker project name (optional, defaults to global)
 
 ### BrowserStack reporter
 

--- a/index.js
+++ b/index.js
@@ -181,9 +181,9 @@ var BrowserStackBrowser = function (
       url: url + '?id=' + id,
       'browserstack.tunnel': true,
       timeout: bsConfig.timeout || 300,
-      project: bsConfig.project,
-      name: bsConfig.name || 'Karma test',
-      build: bsConfig.build ||
+      project: args.project || bsConfig.project,
+      name: args.name || bsConfig.name || 'Karma test',
+      build: args.build || bsConfig.build ||
         process.env.BUILD_NUMBER ||
         process.env.BUILD_TAG ||
         process.env.CI_BUILD_NUMBER ||

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-config-standard": "^4.0.0",
     "eslint-plugin-standard": "^1.2.0",
     "grunt": "~0.4.5",
-    "grunt-auto-release": "~0.0.2",
+    "grunt-auto-release": "0.0.6",
     "grunt-bump": "~0.5.0",
     "grunt-conventional-changelog": "^4.1.0",
     "grunt-conventional-github-releaser": "^0.4.0",


### PR DESCRIPTION
Browserstack uses the `name` property in the browser configuration
to uniquely name sessions within a specific build. If these sessions
do not have a unique name, and are executed sequentially (or with a
concurrency < total # of browsers), browserstack's UI will overwrite
previous results with new ones. In cases where a karma test run is
executed on multiple browsers, this isn't really desirable.

While I was at it, I also incorporated changes from #71, and
updated the README to also include documentation for that change. With
this patch, `name`, `project`, and `build`, may all be overridden on
a per browser basis.