### PR TITLE
Remove support for node 0.10 and 0.12, add support for node 6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
+  - "6"
 
 # Make sure we have new npm on Node 0.10.
 before_install:


### PR DESCRIPTION
According to the Node Foundation's LTS working group, both 0.10 and 0.12 have been EOL'd (https://github.com/nodejs/LTS), while both 4 and 6 are actively supported. This patch removes unsupported versions from the test matrix, and adds those that are.

The extended concern here is that explicit and transient dependencies are starting to be converted to ES2015, creating a line beyond which all greenkeeper updates will fail. In this particular case, the transient dependency `git-remote-origin-url` is causing grunt to fail.