### PR TITLE
feat: pass forcelocal to tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ module.exports = function(config) {
 - `proxyUser` the username used for authentication with your proxy (optional)
 - `proxyPass` the password used for authentication with your proxy (optional)
 - `proxyProtocol` the protocol of your proxy (optional. default: `http`. valid: `http` or `https`)
+- `forcelocal` force traffic through the local BrowserStack tunnel, passes flag through to BrowserStackTunnel
 
 ### Per browser options
 

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
     proxyHost: bsConfig.proxyHost || null,
     proxyPort: bsConfig.proxyPort || null,
     proxyUser: bsConfig.proxyUser || null,
-    proxyPass: bsConfig.proxyPass || null
+    proxyPass: bsConfig.proxyPass || null,
+    forcelocal: bsConfig.forcelocal || null
   }
 
   if (bsConfig.startTunnel === false) {


### PR DESCRIPTION
I would like to configure the `forcelocal` flag through my `karma.conf` file. It doesn't appear like this gets passed through to the tunnel. This PR passes along the `forcelocal` flag.