### PR TITLE
Upgrade to browserstacktunnel-wrapper 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
     "browserstack": "1.5.0",
-    "browserstacktunnel-wrapper": "~1.4.2",
+    "browserstacktunnel-wrapper": "~2.0.1",
     "q": "~1.4.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Use browserstacktunnel-wrapper 2.0.1 as it allows users to run tests behind proxy (pghalliday/node-BrowserStackTunnel/pull/28).