### PR TITLE
fixes issue #62 by making sure to call workerManager.stopPolling in u…

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
       }
 
       if (workerManager.isPolling) {
+        log.debug('Exiting tests; stopping polling')
         workerManager.stopPolling()
       }
 
@@ -240,6 +241,15 @@ var BrowserStackBrowser = function (
               log.debug('%s job with id %s has been deleted.', browserName, workerId)
               break
           }
+
+          emitter.on('exit', function (done) {
+            if (workerManager.isPolling) {
+              log.debug('Exiting tests; stopping polling')
+              workerManager.stopPolling()
+            }
+
+            done()
+          })
         })
       })
     }, function () {


### PR DESCRIPTION
…se cases where the tunnel is launched externally

The bit of code that called `workerManager.stopPolling()` only existed in the code path when the plugin was in charge of launching the browser (within `createBrowserStackTunnel`). 

I've added that logic to the code path where the BS tunnel is launched externally. This fixes the issue where the karma-browserstack-launcher process hangs even after completing tests. 