### PR TITLE
Upgrade browserstack to v1.5.1, which patches a HIGH risk vulnerability of https-proxy-agent dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
-    "browserstack": "1.5.0",
+    "browserstack": "1.5.1",
     "browserstacktunnel-wrapper": "~2.0.2",
     "q": "~1.5.0"
   },


### PR DESCRIPTION
It patches a high risk vulnerability of https-proxy-agent dependency.
https://nodesecurity.io/advisories/593