### PR TITLE
Catch errors thrown by client.createWorker

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ var BrowserStackBrowser = function (
           }
         })
       })
-    }, function () {
+    }).catch(function () {
       emitter.emit('browser_process_failure', self)
     })
   }


### PR DESCRIPTION
When using the `.then($1, $2)` function, any errors thrown from `$1` will *not* be delegated to `$2`. Changing to `.then($1).catch($2)` makes sure that even errors from `$1` gets delegated to `$2`.

Found by this proposed standard rule: standard/eslint-config-standard#129