### PR TITLE
fix: graceful-fs incompatablity

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
     "browserstack": "1.5.1",
-    "browserstacktunnel-wrapper": "~2.0.2",
+    "browserstacktunnel-wrapper": "~2.0.4",
     "q": "~1.5.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Version 2.0.2 of `browserstacktunnel-wrapper` has a security issue due to a dependency down the tree. We should update to `2.0.4` which fixes it.