### PR TITLE
fix: make configuration options work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ module.exports = function(config) {
 - `username` your BS username, you can also use `BROWSERSTACK_USERNAME` env variable.
 - `accessKey` your BS access key, you can also use `BROWSERSTACK_ACCESS_KEY` env variable.
 - `startTunnel` do you wanna establish the BrowserStack tunnel ? (defaults to `true`)
-- `tunnelIdentifier` in case you want to start the BrowserStack tunnel outside `karma` by setting `startTunnel` to `false`, set the identifier passed to the `-localIdentifier` option here (optional)
+- `tunnelIdentifier`/`localIdentifier` in case you want to start the BrowserStack tunnel outside `karma` by setting `startTunnel` to `false`, set the identifier passed to the `-localIdentifier` option here (optional)
 - `retryLimit` how many times do you want to retry to capture the browser ? (defaults to `3`)
 - `captureTimeout` the browser capture timeout (defaults to `120`)
 - `timeout` the BS worker timeout (defaults to `300`

--- a/index.js
+++ b/index.js
@@ -13,7 +13,11 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
 
   const bsAccesskey = process.env.BROWSERSTACK_ACCESS_KEY || process.env.BROWSER_STACK_ACCESS_KEY || bsConfig.accessKey
   const bsLocal = new browserstack.Local()
-  const bsLocalArgs = { key: bsAccesskey }
+  const bsLocalArgs = {
+    key: bsAccesskey,
+    localIdentifier: bsConfig.localIdentifier || bsConfig.tunnelIdentifier || undefined,
+    forceLocal: bsConfig.forceLocal || undefined
+  }
   const deferred = Q.defer()
 
   log.debug('Starting BrowserStackLocal')


### PR DESCRIPTION
This MR will again pass in the config options `tunnelIdentifier`,
`localIdentifier` and `forceLocal` to the npm package that
creates the Browserstack Local tunnel.

Resolves #155 #156