### PR TITLE
Prevent addition of phantom timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ var BrowserStackBrowser = function (
             case 'running':
               log.debug('%s job started with id %s', browserName, workerId)
 
-              if (captureTimeout && !captured) {
+              if (captureTimeout && !captured && alreadyKilling == null) {
                 captureTimeoutId = setTimeout(self._onTimeout, captureTimeout)
               }
               break


### PR DESCRIPTION
### Issue
Occasionally, the worker registers a status of "running" after a test has been killed, and thus adds a phantom timeout. This prevents the addition of said phantom timeout. 