### PR TITLE
removed incompatible cap from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module.exports = function(config) {
 - `name` the BS worker name (optional, defaults to global)
 - `project` the BS worker project name (optional, defaults to global)
 
-> **Note:** you can also pass through any additional options supported by browserstack. (EG. `timezone`, `resolution`, etc.)  
+> **Note:** you can also pass through any additional options supported by browserstack. (EG. `url`, `resolution`, etc.)  
 See https://www.browserstack.com/automate/capabilities for a full list of supported options.
 
 ### BrowserStack reporter


### PR DESCRIPTION
Removed `timezone` cap from README since its not supported.