### PR TITLE
Add session keep alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.6.0"></a>
+# [1.6.0](https://github.com/karma-runner/karma-browserstack-launcher/compare/v1.5.1...v1.6.0) (2020-01-16)
+
+
+### Features
+
+* Added new configuration keys allowing for keep alive (via screenshot) of session / worker at a configurable interval 
+
 <a name="1.5.1"></a>
 # [1.5.1](https://github.com/karma-runner/karma-browserstack-launcher/compare/v1.3.0...v1.5.1) (2019-04-03)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ module.exports = function(config) {
 - `proxyProtocol` the protocol of your proxy (optional. default: `http`. valid: `http` or `https`)
 - `forcelocal` force traffic through the local BrowserStack tunnel, passes flag through to BrowserStackTunnel
 - `video` enable video recording of session on BrowserStack (defaults to `true`)
+- `keepAlive` periodically issue a _takeScreenshot_ command to keep long test sessions from timing out (defaults to `false`)
+- `keepAliveDelay` the number of milliseconds to wait between issuing keep alive commands (defaults to `60000`ms; 1 minute)
 
 ### Per browser options
 

--- a/index.js
+++ b/index.js
@@ -213,7 +213,8 @@ var BrowserStackBrowser = function (
       } catch (e) {
         log.error(e)
       }
-      setTimeout(startKeepAlive, bsConfig.keepAliveDelay)
+      var delay = bsConfig.keepAliveDelay || 60000
+      setTimeout(startKeepAlive, delay)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -188,6 +188,7 @@ var BrowserStackBrowser = function (
               break
 
             case 'delete':
+              keepAliveEnabled = false
               log.debug('%s job with id %s has been deleted.', browserName, workerId)
               break
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-browserstack-launcher",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "Adam Netočný <netocny@gmail.com>",
     "Mark Trostler <mark@zzo.com>",
     "Mattias Ekstrand <mattias.ekstrand@gmail.com>",
-    "Michael Krotscheck <krotscheck@gmail.com>"
+    "Michael Krotscheck <krotscheck@gmail.com>",
+    "Jason Holt Smith <bicarbon8@gmail.com>"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-browserstack-launcher",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "A Karma plugin. Launch any browser on BrowserStack!",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
### Changes:
* adds ability to call api client worker periodically with instructions to take a screenshot. this keeps the session active so test runs containing thousands of tests or long running tests will not fail due to session timeout due to inactivity
* allows for overriding default 1 minute delay between keep alive commands to send either more frequently or less frequently
* changes are backwards compatible and the keep alive is disabled by default

### Note:
* added benefit of periodic screenshots is that you needn't wait for the test to complete to be able to view the video and instead can check the screenshots to see test status in BrowserStack's dashboard