### PR TITLE
Add support for localIdentifier argument in browserstack-local

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const browserstack = require('browserstack-local')
 const workerManager = require('./worker-manager')
 const BrowserStackReporter = require('./browserstack-reporter')
 
-var bsLocalIdentifier = null;
+var bsLocalIdentifier = ''
 
 var createBrowserStackTunnel = function (logger, config, emitter) {
   const log = logger.create('launcher.browserstack')

--- a/index.js
+++ b/index.js
@@ -13,7 +13,12 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
 
   const bsAccesskey = process.env.BROWSERSTACK_ACCESS_KEY || process.env.BROWSER_STACK_ACCESS_KEY || bsConfig.accessKey
   const bsLocal = new browserstack.Local()
-  const bsLocalArgs = { key: bsAccesskey }
+  var bsLocalArgs = { key: bsAccesskey }
+  const bsUseLocalIdentifier = bsConfig.useLocalIdentifier || false
+  if (bsUseLocalIdentifier === true) {
+    var r = Math.random().toString(36).substring(10)
+    bsLocalArgs.localIdentifier = r
+  }
   const deferred = Q.defer()
 
   log.debug('Starting BrowserStackLocal')

--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@ const browserstack = require('browserstack-local')
 const workerManager = require('./worker-manager')
 const BrowserStackReporter = require('./browserstack-reporter')
 
-var bsLocalIdentifier = ''
-
 var createBrowserStackTunnel = function (logger, config, emitter) {
   const log = logger.create('launcher.browserstack')
   const bsConfig = config.browserStack || {}
@@ -16,9 +14,8 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
   const bsAccesskey = process.env.BROWSERSTACK_ACCESS_KEY || process.env.BROWSER_STACK_ACCESS_KEY || bsConfig.accessKey
   const bsLocal = new browserstack.Local()
   var bsLocalArgs = { key: bsAccesskey }
-  const bsUseLocalIdentifier = bsConfig.useLocalIdentifier || false
-  if (bsUseLocalIdentifier === true) {
-    generateLocalIdentifier()
+  const bsLocalIdentifier = bsConfig.localIdentifier
+  if (bsLocalIdentifier) {
     bsLocalArgs.localIdentifier = bsLocalIdentifier
   }
   const deferred = Q.defer()
@@ -40,10 +37,6 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
   return deferred.promise
 }
 
-var generateLocalIdentifier = function () {
-  bsLocalIdentifier = Math.random().toString(36).substring(10)
-}
-
 var createBrowserStackClient = function (/* config.browserStack */config, /* BrowserStack:sessionMapping */ sessionMapping) {
   var env = process.env
 
@@ -63,8 +56,8 @@ var createBrowserStackClient = function (/* config.browserStack */config, /* Bro
 
   if (!config.browserstack || config.browserStack.startTunnel !== false) {
     options.Local = true
-    if (config.useLocalIdentifier === true) {
-      options.LocalIdentifier = bsLocalIdentifier
+    if (config.localIdentifier) {
+      options.LocalIdentifier = config.localIdentifier
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const browserstack = require('browserstack-local')
 const workerManager = require('./worker-manager')
 const BrowserStackReporter = require('./browserstack-reporter')
 
+var bsLocalIdentifier = null;
+
 var createBrowserStackTunnel = function (logger, config, emitter) {
   const log = logger.create('launcher.browserstack')
   const bsConfig = config.browserStack || {}
@@ -16,8 +18,8 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
   var bsLocalArgs = { key: bsAccesskey }
   const bsUseLocalIdentifier = bsConfig.useLocalIdentifier || false
   if (bsUseLocalIdentifier === true) {
-    var r = Math.random().toString(36).substring(10)
-    bsLocalArgs.localIdentifier = r
+    generateLocalIdentifier()
+    bsLocalArgs.localIdentifier = bsLocalIdentifier
   }
   const deferred = Q.defer()
 
@@ -36,6 +38,10 @@ var createBrowserStackTunnel = function (logger, config, emitter) {
   })
 
   return deferred.promise
+}
+
+var generateLocalIdentifier = function () {
+  bsLocalIdentifier = Math.random().toString(36).substring(10)
 }
 
 var createBrowserStackClient = function (/* config.browserStack */config, /* BrowserStack:sessionMapping */ sessionMapping) {
@@ -57,6 +63,9 @@ var createBrowserStackClient = function (/* config.browserStack */config, /* Bro
 
   if (!config.browserstack || config.browserStack.startTunnel !== false) {
     options.Local = true
+    if (config.useLocalIdentifier === true) {
+      options.LocalIdentifier = bsLocalIdentifier
+    }
   }
 
   sessionMapping.credentials = {


### PR DESCRIPTION
### Changes:
- adding support for browserstack-local library's argument of _localIdentifier_ that enables running multiple concurrent instances of the browserstack-local VPN using the same accesskey by way of adding a new configuration key of _localIdentifier_ to the _browserStack_ configuration

### Note:
- setting _localIdentifier_ to a string value will set the same on starting the browserstack-local instance as well as include it in the _options_ passed to the BrowserStack Client creation and the Browser itself

### Usage: (karma.conf.js)
```javascript
module.exports = function(config) {
  config.set({
    browserStack: {
      username: 'someUsername',
      accessKey: 'someAccessKey',
      localIdentifier: Math.random().toString(36).substr(0, 10)
    },
    ...
  })
}
```

### References:
- https://github.com/browserstack/browserstack-local-nodejs/blob/master/lib/Local.js#L125 for the line of code showing support for this argument
- https://github.com/browserstack/browserstack-local-nodejs/blob/master/README.md for an example using this _localIdentifier_ argument